### PR TITLE
simplifying install to include all of bundle

### DIFF
--- a/debian/on-web-ui.install
+++ b/debian/on-web-ui.install
@@ -1,7 +1,7 @@
 build/bundle /opt/monorail/static/http
-build/common /opt/monorail/static/http/common
-build/monorail /opt/monorail/static/http/monorail
-build/onrack /opt/monorail/static/http/onrack
-build/workflow_editor /opt/monorail/static/http/workflow_editor
+build/common /opt/monorail/static/http
+build/monorail /opt/monorail/static/http
+build/onrack /opt/monorail/static/http
+build/workflow_editor /opt/monorail/static/http
 on-web-ui_commitstring.txt /opt/monorail/static/http/on-web-ui
 index.html /opt/monorail/static/http


### PR DESCRIPTION
simplified deb.install file with directory structures, installing all of bundle and removing wildcards.

result will build on Jenkins build VM clone now

you can verify what's where in the resulting debian with the command:

```
dpkg-deb -c ../on-web-ui_*_amd64.deb | less
```

after it's built. Example results from my trial at https://gist.github.com/heckj/522bc884d4bd23cccdcf for review with this PR
