### PR TITLE
Simplify build process by copying apps/index.html during gulp assets task.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ apps/tutorial
 build
 checkstyle-result.xml
 dev/node_modules
-dev/slush_app/node_modules
+dev/slush_app
 node_modules
 npm-debug.log
 server/node_modules

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
+# TODO: turn this into a shell script
 [submodule "apps/graph_stream"]
 	path = apps/graph_stream
 	url = ssh://git@eos2git.cec.lab.emc.com/poultr2/graph_stream.git

--- a/debian/on-web-ui.dirs
+++ b/debian/on-web-ui.dirs
@@ -1,6 +1,1 @@
 /opt/monorail/static/http
-/opt/monorail/static/http/common
-/opt/monorail/static/http/bundle
-/opt/monorail/static/http/monorail
-/opt/monorail/static/http/onrack
-/opt/monorail/static/http/workflow_editor

--- a/debian/on-web-ui.install
+++ b/debian/on-web-ui.install
@@ -1,7 +1,2 @@
-build/bundle /opt/monorail/static/http
-build/common /opt/monorail/static/http
-build/monorail /opt/monorail/static/http
-build/onrack /opt/monorail/static/http
-build/workflow_editor /opt/monorail/static/http
+build /opt/monorail/static/http
 on-web-ui_commitstring.txt /opt/monorail/static/http/on-web-ui
-apps/index.html /opt/monorail/static/http

--- a/dev/tasks/assets.js
+++ b/dev/tasks/assets.js
@@ -13,6 +13,15 @@ var getFolders = require('../lib/getFolders');
 gulp.task('assets', function() {
   var streams = [];
 
+  var indexSource = path.join('..', 'apps', 'index.html'),
+      indexTarget = path.join('..', 'build');
+  streams.push(
+    gulp.src(indexSource)
+      .pipe(changed(indexTarget))
+      .pipe(gulp.dest(indexTarget))
+      .pipe(size({title: 'index.html'}))
+  );
+
   // Copy app assets into build directory.
   var apps = getFolders(path.join(__dirname, '..', '..', 'apps'));
   apps.forEach(function (appName) {

--- a/server/build_server.js
+++ b/server/build_server.js
@@ -8,6 +8,8 @@ var express = require('express'),
 
 var server = express();
 
+module.exports = server;
+
 server.set('port', (process.env.ONWEBUI_PORT || 5000));
 
 var publicPath = path.join(__dirname, '..', 'build');


### PR DESCRIPTION
Originally the file was copied during debian packaging. It makes more sense to do this during `gulp build`