### PR TITLE
Adds deploy script for gh-pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 .vagrant
+.publish
 apps/*/config/custom.json
 apps/*/node_modules
 apps/graph_stream
@@ -9,7 +10,6 @@ apps/tutorial
 build
 checkstyle-result.xml
 dev/node_modules
-dev/slush_app
 node_modules
 npm-debug.log
 server/node_modules

--- a/apps/common/views/EMCTab.js
+++ b/apps/common/views/EMCTab.js
@@ -52,7 +52,7 @@ export default class AppHeader extends Component {
         <img
             className="emc-logo"
             style={[this.css.logo]}
-            src="/common/WhiteLogoLarge.png"
+            src="common/WhiteLogoLarge.png"
             alt="EMC" />
 
       </a>

--- a/apps/index.html
+++ b/apps/index.html
@@ -3,9 +3,9 @@
   <head>
     <title>MonoRail</title>
     <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.4.0/css/font-awesome.min.css">
-    <link rel="stylesheet" href="/common/main.css">
-    <script src="/bundle/common.js"></script>
-    <script src="/bundle/monorail.js"></script>
+    <link rel="stylesheet" href="common/main.css">
+    <script src="bundle/common.js"></script>
+    <script src="bundle/monorail.js"></script>
   </head>
   <body></body>
 </html>

--- a/dev/gulpfile.js
+++ b/dev/gulpfile.js
@@ -35,4 +35,7 @@ require('./tasks/serve');
 require('./tasks/sync');
 require('./tasks/watch');
 
+// deploy
+require('./tasks/deploy');
+
 global.gulp.task('default', ['sync']);

--- a/dev/tasks/deploy.js
+++ b/dev/tasks/deploy.js
@@ -1,0 +1,16 @@
+// Copyright 2015, EMC, Inc.
+
+'use strict';
+/* global gulp, path */
+
+var ghPages = require('gulp-gh-pages');
+
+var rootDir = path.join(__dirname, '..', '..');
+
+gulp.task('deploy', function() {
+  let buildSrc = path.join(rootDir, 'build', '**', '*');
+  console.log(buildSrc);
+  return gulp.src(buildSrc).pipe(ghPages({
+    remoteUrl: 'https://github.com/RackHD/on-web-ui'
+  }));
+});

--- a/package.json
+++ b/package.json
@@ -35,10 +35,12 @@
     "babel-polyfill": "^6.3.14",
     "eslint": "^1.10.3",
     "eslint-plugin-react": "^3.11.3",
+    "gulp-gh-pages": "^0.5.4",
     "karma-cli": "^0.1.1"
   },
   "scripts": {
-    "build": "./node_modules/.bin/gulp dev/gulpfile.js",
+    "build": "cd ./dev && ./node_modules/.bin/gulp build --production && cd ..",
+    "deploy": "npm run-script build && cd ./dev && ./node_modules/.bin/gulp deploy",
     "install-apps": "npm link ./apps/*/",
     "install-dev-slush-app": "npm link ./dev/slush_app",
     "install-dev": "cd ./dev && npm install && cd ..",


### PR DESCRIPTION
`npm run-script deploy` - rebuild code for production and updates `gh-pages` branch.

See: http://rackhd.github.io/on-web-ui