### PR TITLE
Adds 2.0 api client, and settings redirect

### DIFF
--- a/apps/common/config/custom.json.example
+++ b/apps/common/config/custom.json.example
@@ -4,7 +4,7 @@
   "Enable_RackHD_SSL": false,
   "MonoRail_API": "localhost:9090/api/1.1",
   "MonoRail_WSS": "localhost:9090",
-  "RackHD_API": "localhost:9090/api/2",
+  "RackHD_API": "localhost:9090/api/2.0",
   "RackHD_API_Auth_Token": "",
   "RedFish_API": "localhost:9090/redfish"
 }

--- a/apps/common/config/defaults.json
+++ b/apps/common/config/defaults.json
@@ -4,7 +4,7 @@
   "Enable_RackHD_SSL": false,
   "MonoRail_API": "localhost:9090/api/1.1",
   "MonoRail_WSS": "localhost:9090",
-  "RackHD_API": "localhost:9090/api/2",
+  "RackHD_API": "localhost:9090/api/2.0",
   "RackHD_API_Auth_Token": "",
   "RedFish_API": "localhost:9090/redfish"
 }

--- a/apps/common/messengers/RackHDRestAPIv2_0.js
+++ b/apps/common/messengers/RackHDRestAPIv2_0.js
@@ -1,0 +1,36 @@
+// Copyright 2015, EMC, Inc.
+
+'use strict';
+
+import config from '../config/index';
+
+import Swagger from 'swagger-client';
+
+const API = 'http' +
+  (config.check('Enable_RackHD_SSL') ? 's' : '') + '://' +
+  config.RackHD_API;
+
+const TOKEN = config.check('Enable_RackHD_API_Auth') ?
+  config.RackHD_API_Auth_Token : '';
+
+let authorizations = {};
+
+if (config.check('Enable_RackHD_API_Auth')) {
+  authorizations['Authentication-Token'] =
+    new Swagger.ApiKeyAuthorization('Authorization', 'JWT ' + TOKEN, 'header');
+}
+
+let swaggerPromise = new Swagger({
+  usePromise: true,
+  authorizations : authorizations,
+  // success: () => console.log('RackHD 2.0 Rest API is ready.'),
+  url: API + '/swagger'
+});
+
+module.exports = new Promise((resolve, reject) => {
+  swaggerPromise.catch(reject).then(swaggerClient => {
+    let api2_0 = swaggerClient['/api/2.0'];
+    Object.defineProperty(api2_0, 'swagger', {value: swaggerClient});
+    resolve(api2_0);
+  });
+});

--- a/apps/common/views/EMCTab.js
+++ b/apps/common/views/EMCTab.js
@@ -6,7 +6,7 @@ import React, { Component } from 'react';
 import radium from 'radium';
 
 @radium
-export default class AppHeader extends Component {
+export default class EMCTab extends Component {
 
   static defaultProps = {
     opacity: 1

--- a/apps/monorail/routes.js
+++ b/apps/monorail/routes.js
@@ -9,6 +9,7 @@ import { Router, Route, IndexRedirect, hashHistory } from 'react-router';
 
 import onReady from 'rui-common/lib/onReady';
 import NotFound from 'rui-common/views/NotFound';
+import RackHDRestAPIv2_0 from 'rui-common/messengers/RackHDRestAPIv2_0';
 
 import ManagementConsole from 'rui-management-console/views/ManagementConsole';
 import NetworkTopology from 'rui-network-topology/views/NetworkTopology';
@@ -19,7 +20,7 @@ import WorkflowEditor from 'rui-workflow-editor/views/WorkflowEditor';
 import MonoRailApp from './views/MonoRailApp'
 import Settings from './views/Settings';
 
-onReady(() => {
+const main = () => {
   if (global.isTesting) { return; }
 
   let container = document.createElement('div');
@@ -38,8 +39,13 @@ onReady(() => {
         <Route name="Workflow Editor" path="/we" component={WorkflowEditor} />
         <Route name="Workflow Editor" path="/we/:workflow" component={WorkflowEditor} />
         <Route name="Settings" path="/settings" component={Settings} />
+        <Route name="Settings" path="/settings/help" component={Settings} />
         <Route name="Not Found" path="*" component={NotFound} />
       </Route>
     </Router>
   ), container);
+};
+
+onReady(() => {
+  RackHDRestAPIv2_0.then(main).catch(main);
 });

--- a/apps/monorail/views/MonoRailApp.js
+++ b/apps/monorail/views/MonoRailApp.js
@@ -19,6 +19,9 @@ import emcTheme from 'rui-common/lib/emcTheme';
 import FormatHelpers from 'rui-common/mixins/FormatHelpers';
 import SplitView from 'rui-common/views/SplitView';
 
+import RackHDRestAPIv2_0 from 'rui-common/messengers/RackHDRestAPIv2_0';
+import RackHDRestAPIv1_1 from 'rui-common/messengers/RackHDRestAPIv1_1';
+
 import MonoRailToolbar from './MonoRailToolbar';
 import Logs from './Logs';
 import icons from '../icons';
@@ -33,7 +36,8 @@ export default class MonoRailApp extends Component {
   };
 
   static contextTypes = {
-    muiTheme: PropTypes.any
+    muiTheme: PropTypes.any,
+    router: PropTypes.any
   };
 
   static childContextTypes = {
@@ -50,6 +54,19 @@ export default class MonoRailApp extends Component {
       muiTheme: emcTheme,
       routes: this.props.routes
     };
+  }
+
+  componentWillMount() {
+    let route = this.props.routes && this.props.routes[1];
+    if (!route || route.name !== 'Settings') {
+      let settingsRedirect = err => {
+        this.context.router.push('/settings/help');
+      };
+
+      RackHDRestAPIv2_0.catch(settingsRedirect).then(() => {
+        RackHDRestAPIv1_1.config.get().catch(settingsRedirect);
+      });
+    }
   }
 
   toolbarTimer = null;

--- a/apps/monorail/views/Settings.js
+++ b/apps/monorail/views/Settings.js
@@ -23,6 +23,10 @@ export default class Settings extends Component {
     css: {}
   };
 
+  static contextTypes = {
+    routes: PropTypes.any
+  };
+
   css = {
     root: {}
   };
@@ -42,6 +46,9 @@ export default class Settings extends Component {
   render() {
     let { props } = this;
 
+    let route = this.context.routes[1],
+        showHelp = route.path.lastIndexOf('/help') !== -1;
+
     let css = {
       root: [
         this.css.root,
@@ -53,6 +60,9 @@ export default class Settings extends Component {
     return (
       <div style={css.root} {...props}>
         <div style={{padding: 20}}>
+          {showHelp && <p style={{background: 'red', padding: 5, borderRadius: 5, color: 'white'}}>
+            Failed to reach RackHD API Endpoints, please correctly adjust these settings.
+          </p>}
           <fieldset>
             <legend style={{padding: 5}}>RacKHD </legend>
             <Toggle
@@ -91,13 +101,13 @@ export default class Settings extends Component {
                   floatingLabelText="RackHD API Auth Token"
                   onChange={(e) => this.setState({rackhdAuthToken: e.target.value})} />
             </fieldset>}
-            {/*<TextField
+            <TextField
                 ref="rackhdAPI"
                 fullWidth={true}
                 hintText={this.rackhdAPI}
                 value={this.state.rackhdAPI}
                 floatingLabelText="RackHD Northbound API v2"
-                onChange={(e) => this.setState({rackhdAPI: e.target.value})} />*/}
+                onChange={(e) => this.setState({rackhdAPI: e.target.value})} />
             <TextField
                 ref="monorailAPI"
                 fullWidth={true}
@@ -182,7 +192,7 @@ export default class Settings extends Component {
     this.enableSSL = this.state.enableSSL;
     this.monorailAPI = this.state.monorailAPI;
     this.monorailWSS = this.state.monorailWSS;
-    // this.rackhdAPI = this.state.rackhdAPI;
+    this.rackhdAPI = this.state.rackhdAPI;
     this.rackhdAuthToken = this.state.rackhdAuthToken;
     // this.redfishAPI = this.state.redfishAPI;
     setTimeout(() => window.location.reload(), 250);

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "react-router": "^2.0.0",
     "react-select": "^1.0.0-beta9",
     "react-tap-event-plugin": "^0.2.2",
-    "superagent": "^1.6.0"
+    "superagent": "^1.6.0",
+    "swagger-client": "^2.1.13"
   },
   "devDependencies": {
     "babel": "^6.5.2",


### PR DESCRIPTION
Initial setup for RackHD 2.0 API using `swagger-client`. Also adds a check to make sure the UI can reach both 2.0 and 1.1 endpoints. If not it will automatically redirect to the settings page with a notice to update the settings. 