### PR TITLE
Miscellaneous improvements and bug fixes

### DIFF
--- a/apps/common/lib/emcTheme.js
+++ b/apps/common/lib/emcTheme.js
@@ -3,10 +3,10 @@
 import merge from 'lodash/merge';
 import Color from 'color';
 
-import getMuiTheme from 'material-ui/lib/styles/getMuiTheme';
+import getMuiTheme from 'material-ui/build/styles/getMuiTheme';
 
-import * as muiColors from 'material-ui/lib/styles/colors';
-import darkBaseTheme from 'material-ui/lib/styles/baseThemes/darkBaseTheme';
+import * as muiColors from 'material-ui/build/styles/colors';
+import darkBaseTheme from 'material-ui/build/styles/baseThemes/darkBaseTheme';
 
 import emcColors from './emcColors';
 

--- a/apps/common/messengers/RackHDRestAPIv2_0.js
+++ b/apps/common/messengers/RackHDRestAPIv2_0.js
@@ -23,14 +23,31 @@ if (config.check('Enable_RackHD_API_Auth')) {
 let swaggerPromise = new Swagger({
   usePromise: true,
   authorizations : authorizations,
-  // success: () => console.log('RackHD 2.0 Rest API is ready.'),
   url: API + '/swagger'
 });
 
 module.exports = new Promise((resolve, reject) => {
-  swaggerPromise.catch(reject).then(swaggerClient => {
+  let done = false;
+
+  const finish = (api2_0) => {
+    if (done) return;
+    done = true;
+    if (!api2_0) {
+      let err = new Error('Failed to load RackHD API 2.0');
+      console.error(err);
+      return reject(err);
+    }
+    console.log('RackHD API 2.0 is ready.'),
+    resolve(api2_0);
+  }
+
+  const failed = () => finish();
+
+  setTimeout(failed, 5000);
+
+  swaggerPromise.catch(failed).then(swaggerClient => {
     let api2_0 = swaggerClient['/api/2.0'];
     Object.defineProperty(api2_0, 'swagger', {value: swaggerClient});
-    resolve(api2_0);
+    finish(api2_0);
   });
 });

--- a/apps/common/views/AppContainer.js
+++ b/apps/common/views/AppContainer.js
@@ -6,7 +6,7 @@ import React, { Component, PropTypes } from 'react';
 import radium from 'radium';
 
 import { AppCanvas } from 'material-ui';
-import MuiThemeProvider from 'material-ui/lib/MuiThemeProvider';
+import MuiThemeProvider from 'material-ui/build/styles/MuiThemeProvider';
 
 import ErrorNotification from './ErrorNotification';
 

--- a/apps/common/views/NotFound.js
+++ b/apps/common/views/NotFound.js
@@ -11,7 +11,7 @@ export default class NotFound extends Component {
   render() {
     return (
       <div className="NotFound container">
-        The page you are looking for could not be found. Please go <Link href="/">home</Link>
+        The page you are looking for could not be found. Please go <Link to="/">home</Link>
       </div>
     );
   }

--- a/apps/monorail/routes.js
+++ b/apps/monorail/routes.js
@@ -9,7 +9,6 @@ import { Router, Route, IndexRedirect, hashHistory } from 'react-router';
 
 import onReady from 'rui-common/lib/onReady';
 import NotFound from 'rui-common/views/NotFound';
-import RackHDRestAPIv2_0 from 'rui-common/messengers/RackHDRestAPIv2_0';
 
 import ManagementConsole from 'rui-management-console/views/ManagementConsole';
 import NetworkTopology from 'rui-network-topology/views/NetworkTopology';
@@ -39,13 +38,10 @@ const main = () => {
         <Route name="Workflow Editor" path="/we" component={WorkflowEditor} />
         <Route name="Workflow Editor" path="/we/:workflow" component={WorkflowEditor} />
         <Route name="Settings" path="/settings" component={Settings} />
-        <Route name="Settings" path="/settings/help" component={Settings} />
         <Route name="Not Found" path="*" component={NotFound} />
       </Route>
     </Router>
   ), container);
 };
 
-onReady(() => {
-  RackHDRestAPIv2_0.then(main).catch(main);
-});
+onReady(main);

--- a/apps/monorail/views/EndpointInput.js
+++ b/apps/monorail/views/EndpointInput.js
@@ -1,0 +1,75 @@
+// Copyright 2015, EMC, Inc.
+
+'use strict';
+
+import React, { Component, PropTypes } from 'react';
+import radium from 'radium';
+
+import { TextField } from 'material-ui';
+
+@radium
+export default class EndpointInput extends Component {
+
+  static defaultProps = {
+    check: function () {},
+    checkWait: 500,
+    floatingLabelText: 'Floating Label Text',
+    hintText: 'Hint Text',
+    onChange: function ({ checkCallback }) { checkCallback(); },
+    value: ''
+  };
+
+  state = {
+    errorStyle: {},
+    errorText: ''
+  };
+
+  resolve = (reason, cb) => {
+    this.setState({
+      errorStyle: {color: 'green'},
+      errorText: reason
+    }, cb);
+  }
+
+  reject = (reason, cb) => {
+    this.setState({
+      errorStyle: {color: 'red'},
+      errorText: reason
+    }, cb);
+  }
+
+  render() {
+    let { check, checkWait, floatingLabelText, hintText, onChange, value } = this.props,
+        { errorStyle, errorText } = this.state;
+
+    let checkTimer;
+    const checkCallback = () => {
+      clearTimeout(checkTimer);
+      checkTimer = setTimeout(() => {
+        check({
+          resolve: this.resolve,
+          reject: this.reject
+        });
+      }, checkWait);
+    };
+
+    return (
+      <TextField
+        errorStyle={errorStyle}
+        errorText={errorText}
+        floatingLabelText={floatingLabelText}
+        fullWidth={true}
+        hintText={hintText}
+        onChange={(e) => {
+          onChange({
+            checkCallback,
+            event: e,
+            value: e.target.value
+          });
+        }}
+        value={value}
+      />
+    );
+  }
+
+}

--- a/apps/monorail/views/MonoRailApp.js
+++ b/apps/monorail/views/MonoRailApp.js
@@ -11,6 +11,7 @@ import {
     IconButton,
     Popover,
     RaisedButton,
+    RefreshIndicator,
     TextField
   } from 'material-ui';
 
@@ -56,16 +57,25 @@ export default class MonoRailApp extends Component {
     };
   }
 
-  componentWillMount() {
+  componentDidMount() {
     let route = this.props.routes && this.props.routes[1];
-    if (!route || route.name !== 'Settings') {
+
+    if (!route || (route.name !== 'Settings' && route.name !== 'Not Found')) {
       let settingsRedirect = err => {
-        this.context.router.push('/settings/help');
+        this.setState({loadingAPIs: false}, () => {
+          this.context.router.push('/settings');
+        });
       };
 
-      RackHDRestAPIv2_0.catch(settingsRedirect).then(() => {
-        RackHDRestAPIv1_1.config.get().catch(settingsRedirect);
+      RackHDRestAPIv1_1.config.get().catch(settingsRedirect).then(() => {
+        RackHDRestAPIv2_0.catch(settingsRedirect).then(() => {
+          this.setState({loadingAPIs: false});
+        });
       });
+    }
+
+    else {
+      this.setState({loadingAPIs: false});
     }
   }
 
@@ -108,6 +118,7 @@ export default class MonoRailApp extends Component {
   };
 
   state = {
+    loadingAPIs: true,
     isToolbarExpanded: false,
     showLogs: false,
     toolbarWidth: this.props.collapsedToolbarWidth,
@@ -115,6 +126,18 @@ export default class MonoRailApp extends Component {
   };
 
   render() {
+    if (this.state.loadingAPIs) {
+      return <RefreshIndicator
+          size={50}
+          left={window.innerWidth / 2 - 25}
+          top={window.innerHeight / 2 - 25}
+          status="loading"
+          style={{
+            display: 'inline-block',
+            position: 'relative',
+          }} />
+    }
+
     let renderToolbar = ({ width, height }) => {
       return (
         <MonoRailToolbar key="toolbar"

--- a/apps/operations_center/views/ActiveList.js
+++ b/apps/operations_center/views/ActiveList.js
@@ -4,6 +4,7 @@
 
 import React, { Component, PropTypes } from 'react';
 import radium from 'radium';
+import moment from 'moment';
 
 import { RouteHandler, Link } from 'react-router';
 
@@ -104,7 +105,13 @@ export default class MonoRailToolbar extends Component {
     //   return null;
     // };
 
-    let list = this.state.workflows.map(workflow => {
+    let list = this.state.workflows;
+
+    list = list.sort(
+      (a, b) => moment(b.createdAt).unix() - moment(a.createdAt).unix()
+    );
+
+    list = list.map(workflow => {
       let status = workflow.completeEventString ||
         (workflow.cancelled ? 'cancelled' : workflow._status);
 

--- a/apps/workflow_editor/views/WorkflowJSON.js
+++ b/apps/workflow_editor/views/WorkflowJSON.js
@@ -100,12 +100,10 @@ export default class WorkflowJson extends Component {
     if (this.silentUpdating) { return; }
     if (newValue === this.lastValue) { return; }
 
-    let absDiff = Math.abs(newValue.length - this.lastValue.length);
-
     clearTimeout(this.updateTimer);
     this.updateTimer = setTimeout(() => {
-      this.compileJSON(newValue);
-    }, absDiff > 15 ? 6000 : 12000);
+      this.compileJSON();
+    }, 7000);
   }
 
   compileJSON(newJsonObject) {

--- a/apps/workflow_editor/views/WorkflowOverlay.js
+++ b/apps/workflow_editor/views/WorkflowOverlay.js
@@ -5,9 +5,7 @@
 import React, { Component, PropTypes } from 'react';
 import radium from 'radium';
 
-import {
-    CircularProgress
-  } from 'material-ui';
+import { RefreshIndicator } from 'material-ui';
 
 @radium
 export default class WorkflowOverlay extends Component {
@@ -82,10 +80,15 @@ export default class WorkflowOverlay extends Component {
           <li style={{color: '#6cf'}}>Finished</li>
         </ul>
 
-        {state.loading && <CircularProgress
-            mode="indeterminate"
-            size={2}
-            style={{marginTop: 200}} />}
+        {state.loading && <RefreshIndicator
+            size={50}
+            left={0}
+            top={250}
+            status="loading"
+            style={{
+              display: 'inline-block',
+              position: 'relative',
+            }} /> }
       </div>
     );
   }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "elasticsearch": "^10.1.3",
     "gl-matrix": "^2.3.1",
     "lodash": "^4.7.0",
-    "material-ui": "rolandpoulter/material-ui#lib",
+    "material-ui": "rolandpoulter/material-ui#build",
     "moment": "^2.11.2",
     "prismjs": "^1.4.1",
     "radium": "^0.16.6",


### PR DESCRIPTION
* Adds 5 second timeout when loading RackHD 2.0 API using `swagger-client`. (black screen bug)
* Adds refresh indicator to UI when initially loading RackHD 2.0 API using `swagger-client`. (black screen bug)
* Updates Material UI for upstream bug fixes.
* Fixes link in NotFound view.
* Adds endpoint input that automatically checks if 1.1 and 2.0 RackHD API endpoints can be reached. See screenshots.
* Fixes bug where workflow editor JSON text is reverted to old state. Also improves update timer on JSON text.
* Switched CircularProgress loading indicator to RefreshIndicator for WorkflowEditorOverlay.
* Chronological sort of Operation Center's active workflows menu.

![image](https://cloud.githubusercontent.com/assets/51327/14512849/9954e542-0197-11e6-9111-c5c26f4f1b6d.png)