### PR TITLE
Fix graph_canvas socket errors

### DIFF
--- a/src/graph_canvas/views/GraphCanvas.js
+++ b/src/graph_canvas/views/GraphCanvas.js
@@ -158,12 +158,13 @@ export default class GraphCanvas extends Component {
     if (this.props.onSelect) { this.props.onSelect(this.selected); }
   }
 
-  lookup(id) {
+  lookup(id, throwWhenMissing) {
     let obj = this.index[id];
     if (!obj) {
       let err = new Error('GraphCanvas: Unable to find element with id: ' + id);
       err.gcIsSafe = true;
-      throw err;
+      if (throwWhenMissing) throw err;
+      else console.warn(err);
     }
     if (obj.matches) {
       if (obj.matches.length === 1) { return obj.matches[0]; }

--- a/src/graph_canvas/views/elements/Link.js
+++ b/src/graph_canvas/views/elements/Link.js
@@ -221,7 +221,7 @@ export default class GCLinkElement extends Component {
     _retry = _retry || 0;
 
     try {
-      let fromSocket = this.graphCanvas.lookup(this.state.from);
+      let fromSocket = this.graphCanvas.lookup(this.state.from, true);
       if (!fromSocket) { throw new Error(); }
 
       let fromSocketElement = findDOMNode(fromSocket).querySelector('.GraphCanvasSocketIcon'),
@@ -234,7 +234,7 @@ export default class GCLinkElement extends Component {
         toVector = new Vector(this.state.to);
       }
       else {
-        toSocket = this.graphCanvas.lookup(this.state.to);
+        toSocket = this.graphCanvas.lookup(this.state.to, true);
         toSocketElement = findDOMNode(toSocket).querySelector('.GraphCanvasSocketIcon');
         toVector = this.linksManager.getSocketCenter(toSocketElement);
         // if (this.newLink) {


### PR DESCRIPTION
Sometimes the UI will throw an error: "GraphCanvas: Unable to find element with id: socket_76b"

This error was should normally be a warning, it is only necessary to throw when updating the bounds of a Link so the UI can try again because sometimes the Link is ready before the Socket elements it is linking.

Most of the time the error should be silent.