### PR TITLE
fix RAC-4527 & 4528 about workflow editor for RackHD API 2.0

### DIFF
--- a/src/common/stores/WorkflowTemplateStore.js
+++ b/src/common/stores/WorkflowTemplateStore.js
@@ -24,7 +24,6 @@ export default class WorkflowTemplateStore extends Store {
   }
 
   create(id, data) {
-    data.id = id;
     return RackHDRestAPIv2_0.api.workflowsPutGraphs({body: data})
       .then(() => this.insert(id, data))
       .catch(err => this.error(id, err));

--- a/src/management_console/views/workflows/EditWorkflow.js
+++ b/src/management_console/views/workflows/EditWorkflow.js
@@ -117,7 +117,7 @@ export default class EditWorkflow extends Component {
               }} />
           <h5 style={{margin: '15px 0 5px', color: '#666'}}>Workflow JSON:</h5>
           <JsonEditor
-              value={this.state.workflow}
+              value={{"options": this.state.workflow && this.state.workflow.options || {}}}
               updateParentState={this.updateStateFromJsonEditor.bind(this)}
               disabled={this.state.disabled}
               ref="jsonEditor" />
@@ -136,7 +136,11 @@ export default class EditWorkflow extends Component {
       this.workflows.update(this.state.workflow.context.graphId, this.state.workflow).then(() => this.enable());
     }
     else if (this.state.workflow.node) {
-      RackHDRestAPIv2_0.api.workflowsPost({body: this.state.workflow}).then(res => {
+      RackHDRestAPIv2_0.api.nodesPostWorkflowById({
+          body: {"options": this.state.workflow && this.state.workflow.options || {}},
+          identifier: this.state.workflow.node,
+          name: this.state.workflow.name
+      }).then(res => {
         let workflow = res.obj;
         this.enable();
         if (this.props.onDone) {


### PR DESCRIPTION
modify workflow editor to get align with the format of RackHD API 2.0
fixed:
https://rackhd.atlassian.net/browse/RAC-4527
https://rackhd.atlassian.net/browse/RAC-4528

Swagger used in RackHD 2.0 restricts parameters format in API. the "id" field in put new graphs is not allowed, so removing it from the req.body.

Besides, the format of posting a workflow has changed as well, so use "node/id/workflows?name=" to make sure it works.