### PR TITLE
temporary workaround for the third-party module bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "react-select": "^1.0.0-beta14",
     "react-tap-event-plugin": "^2.0.1",
     "superagent": "^2.2.0",
-    "swagger-client": "^2.1.18"
+    "swagger-client": "^2.1.18",
+    "create-react-class": "^15.5.2"
   },
   "devDependencies": {
     "babel": "^6.5.2",


### PR DESCRIPTION
there is recently a "react-input-autosize" module bug https://github.com/JedWatson/react-input-autosize/issues/84 about missing dependency. Fix it by by explicitly adding it into on-web-ui dependencies, otherwise "npm run build" will fail.
Will remove this work around after issue closed.
@xuea1 @changev 