### PR TITLE
[RAC-4531]fix bug: cannot delete or modify poller in Management Console in on-web-ui.

### DIFF
--- a/src/common/stores/PollerStore.js
+++ b/src/common/stores/PollerStore.js
@@ -35,7 +35,7 @@ export default class PollerStore extends Store {
   }
 
   destroy(id) {
-    return RackHDRestAPIv2_0.api.pollersDelete(id)
+    return RackHDRestAPIv2_0.api.pollersDelete({identifier:id})
       .then(() => this.remove(id))
       .catch(err => this.error(id, err));
   }

--- a/src/management_console/views/pollers/EditPoller.js
+++ b/src/management_console/views/pollers/EditPoller.js
@@ -129,7 +129,7 @@ export default class EditPoller extends Component {
               ]}
               onChange={(option) => {
                 let poller = this.state.poller;
-                poller.pollInterval = option && option.value;
+                poller.pollInterval = option && Number(option.value);
                 this.setState({ poller });
               }} />
             <h5 style={{margin: '15px 0 5px', color: '#666'}}>Poller JSON:</h5>
@@ -150,7 +150,15 @@ export default class EditPoller extends Component {
   savePoller() {
     this.disable();
     if (this.state.poller.id) {
-      this.pollers.update(this.state.poller.id, this.state.poller).then(() => this.enable());
+      let poller = this.state.poller;
+      let updateData = {
+          type : poller.type,
+          pollInterval: poller.pollInterval,
+          node : poller.node,
+          config: poller.config,
+          paused: poller.paused
+      };
+      this.pollers.update(this.state.poller.id, updateData).then(() => this.enable());
     }
     else {
       this.pollers.create(this.state.poller).then(() => this.context.router.goBack());

--- a/src/management_console/views/pollers/Poller.js
+++ b/src/management_console/views/pollers/Poller.js
@@ -1,6 +1,7 @@
 // Copyright 2015, EMC, Inc.
 
 import React, { Component } from 'react';
+import { browserHistory } from 'react-router'
 
 import FormatHelpers from 'src-common/lib/FormatHelpers';
 import ConfirmDialog from 'src-common/views/ConfirmDialog';
@@ -50,7 +51,7 @@ export default class Poller extends Component {
             callback={confirmed => {
               if (confirmed) {
                 return this.pollers.destroy(poller.id).
-                  then(() => this.context.router.goBack());
+                  then(() => { browserHistory.goBack(); });
               }
               this.setState({loading: false, confirmDelete: false});
             }}>


### PR DESCRIPTION
Currently, the web ui (127.0.0.1:8080/web-ui) cannot delete or modify poller in Management Console, and it has no response. details in [RAC-4531](https://rackhd.atlassian.net/browse/RAC-4531)

## Cause:
###  cannot delete poller
1. Missing the poller's identifier in REST api.
2. Delete poller successfully, but not go back. Because the code `this.context.router.goBack()` not work, use `browseHistory.goBack()` instead in `Poller.js`

### cannot modify poller
1. Expect number but string instead in 'pollInterval' in RestAPI
2. Too many properties for updating poller, 'patch' method's data only support :

```
properties:
      config:
        description: Poller configuration object
        type: object
      paused:
        description: Asserted if poller is paused
        type: boolean
      pollInterval:
        description: Interval at which poller will run
        type: number
      type:
        description: Type of poller
        enum:
        - ipmi
        - snmp
        - redfish
        - wsman
        type: string
    type: object
```
@panpan0000 @anhou @changev @bbcyyb