### PR TITLE
[RAC-4532]The cancel button in editors doesn't take effect.

### DIFF
--- a/src/management_console/views/files/EditFile.js
+++ b/src/management_console/views/files/EditFile.js
@@ -1,6 +1,7 @@
 // Copyright 2015, EMC, Inc.
 
 import React, { Component, PropTypes } from 'react';
+import { browserHistory } from 'react-router';
 
 import {
     FlatButton,
@@ -41,7 +42,7 @@ export default class EditFile extends Component {
           <ToolbarGroup key={1} lastChild={true}>
             <RaisedButton
                 label="Cancel"
-                onClick={this.routeBack}
+                onClick={browserHistory.goBack.bind(this)}
                 disabled={this.state.disabled} />
             <RaisedButton
                 label="Save"
@@ -85,7 +86,7 @@ export default class EditFile extends Component {
     this.files.update(this.state.file.basename, this.state.file.body).then(() => {
       this.enable();
       this.setState({loading: false});
-      if (isNewFile) this.context.router.goBack();
+      if (isNewFile) browserHistory.goBack();
     });
   }
 

--- a/src/management_console/views/files/File.js
+++ b/src/management_console/views/files/File.js
@@ -1,6 +1,7 @@
 // Copyright 2015, EMC, Inc.
 
 import React, { Component } from 'react';
+import { browserHistory } from 'react-router';
 
 import ConfirmDialog from 'src-common/views/ConfirmDialog';
 import FileStore from 'src-common/stores/FileStore';
@@ -49,7 +50,7 @@ export default class File extends Component {
             callback={confirmed => {
               if (confirmed) {
                 return this.files.destroy(file.id).
-                  then(() => this.context.router.goBack());
+                  then(() => browserHistory.goBack());
               }
               this.setState({loading: false, confirmDelete: false});
             }}>

--- a/src/management_console/views/nodes/EditNode.js
+++ b/src/management_console/views/nodes/EditNode.js
@@ -1,6 +1,7 @@
 // Copyright 2015, EMC, Inc.
 
 import React, { Component, PropTypes } from 'react';
+import { browserHistory } from 'react-router';
 
 import Select from 'react-select';
 
@@ -49,7 +50,7 @@ export default class EditNode extends Component {
           <ToolbarGroup key={1} lastChild={true}>
             <RaisedButton
                 label="Cancel"
-                onClick={this.routeBack}
+                onClick={browserHistory.goBack.bind(this)}
                 disabled={state.disabled} />
             <RaisedButton
                 label="Save"
@@ -111,7 +112,7 @@ export default class EditNode extends Component {
     }
 
     else {
-      this.nodes.create(this.state.node).then(() => this.context.router.goBack());
+      this.nodes.create(this.state.node).then(() => browserHistory.goBack());
     }
   }
 

--- a/src/management_console/views/nodes/Node.js
+++ b/src/management_console/views/nodes/Node.js
@@ -1,6 +1,8 @@
 // Copyright 2015, EMC, Inc.
 
 import React, { Component, PropTypes } from 'react';
+import { browserHistory } from 'react-router';
+
 import moment from 'moment';
 
 import ElasticsearchAPI from 'src-common/messengers/ElasticsearchAPI';
@@ -98,7 +100,7 @@ export default class Node extends Component {
             callback={confirmed => {
               if (confirmed) {
                 return this.nodes.destroy(node.id).
-                  then(() => this.context.router.goBack());
+                  then(() => browserHistory.goBack());
               }
               this.setState({loading: false, confirmDelete: false});
             }}>

--- a/src/management_console/views/pollers/EditPoller.js
+++ b/src/management_console/views/pollers/EditPoller.js
@@ -1,6 +1,7 @@
 // Copyright 2015, EMC, Inc.
 
 import React, { Component, PropTypes } from 'react';
+import { browserHistory } from 'react-router';
 
 import Select from 'react-select';
 
@@ -69,7 +70,7 @@ export default class EditPoller extends Component {
           <ToolbarGroup key={1} lastChild={true}>
             <RaisedButton
                 label="Cancel"
-                onClick={this.routeBack}
+                onClick={browserHistory.goBack.bind(this)}
                 disabled={this.state.disabled} />
             <RaisedButton
                 label="Save"
@@ -161,7 +162,7 @@ export default class EditPoller extends Component {
       this.pollers.update(this.state.poller.id, updateData).then(() => this.enable());
     }
     else {
-      this.pollers.create(this.state.poller).then(() => this.context.router.goBack());
+      this.pollers.create(this.state.poller).then(() => browserHistory.goBack());
     }
   }
 

--- a/src/management_console/views/profiles/EditProfile.js
+++ b/src/management_console/views/profiles/EditProfile.js
@@ -1,6 +1,7 @@
 // Copyright 2015, EMC, Inc.
 
 import React, { Component, PropTypes } from 'react';
+import { browserHistory } from 'react-router';
 
 import {
     FlatButton,
@@ -41,7 +42,7 @@ export default class EditProfile extends Component {
           <ToolbarGroup key={1} lastChild={true}>
             <RaisedButton
                 label="Cancel"
-                onClick={this.routeBack}
+                onClick={browserHistory.goBack.bind(this)}
                 disabled={this.state.disabled} />
             <RaisedButton
                 label="Save"
@@ -89,7 +90,7 @@ export default class EditProfile extends Component {
     this.profiles.update(this.state.profile.name, this.state.profile.contents).then(() => {
       this.enable();
       this.setState({loading: false});
-      if (isNewProfile) this.context.router.goBack();
+      if (isNewProfile) browserHistory.goBack();
     });
   }
 

--- a/src/management_console/views/skus/EditSku.js
+++ b/src/management_console/views/skus/EditSku.js
@@ -1,6 +1,7 @@
 // Copyright 2015, EMC, Inc.
 
 import React, { Component, PropTypes } from 'react';
+import { browserHistory } from 'react-router';
 
 import mixin from 'src-common/lib/mixin';
 
@@ -45,7 +46,7 @@ export default class EditSku extends Component {
           <ToolbarGroup key={1} lastChild={true}>
             <RaisedButton
                 label="Cancel"
-                onClick={this.routeBack}
+                onClick={browserHistory.goBack.bind(this)}
                 disabled={this.state.disabled} />
             <RaisedButton
                 label="Save"
@@ -87,7 +88,7 @@ export default class EditSku extends Component {
       this.skus.update(this.state.sku.id, this.state.sku).then(() => this.enable());
     }
     else {
-      this.skus.create(this.state.sku).then(() => this.context.router.goBack());
+      this.skus.create(this.state.sku).then(() => browserHistory.goBack());
     }
   }
 

--- a/src/management_console/views/skus/Sku.js
+++ b/src/management_console/views/skus/Sku.js
@@ -1,6 +1,7 @@
 // Copyright 2015, EMC, Inc.
 
 import React, { Component, PropTypes } from 'react';
+import { browserHistory } from 'react-router';
 
 import ConfirmDialog from 'src-common/views/ConfirmDialog';
 import SkuStore from 'src-common/stores/SkuStore';
@@ -51,7 +52,7 @@ export default class Sku extends Component {
             callback={confirmed => {
               if (confirmed) {
                 return this.skus.destroy(sku.id).
-                  then(() => this.context.router.goBack());
+                  then(() => browserHistory.goBack());
               }
               this.setState({loading: false, confirmDelete: false});
             }}>

--- a/src/management_console/views/templates/EditTemplate.js
+++ b/src/management_console/views/templates/EditTemplate.js
@@ -1,6 +1,7 @@
 // Copyright 2015, EMC, Inc.
 
 import React, { Component, PropTypes } from 'react';
+import { browserHistory } from 'react-router';
 
 import {
     FlatButton,
@@ -39,7 +40,7 @@ export default class EditTemplate extends Component {
           <ToolbarGroup key={1} lastChild={true}>
             <RaisedButton
                 label="Cancel"
-                onClick={this.routeBack}
+                onClick={browserHistory.goBack.bind(this)}
                 disabled={this.state.disabled} />
             <RaisedButton
                 label="Save"
@@ -87,7 +88,7 @@ export default class EditTemplate extends Component {
     this.templates.update(this.state.template.name, this.state.template.contents).then(() => {
       this.enable();
       this.setState({loading: false});
-      if (isNewTemplate) this.context.router.goBack();
+      if (isNewTemplate) browserHistory.goBack();
     });
   }
 

--- a/src/management_console/views/workflows/EditWorkflow.js
+++ b/src/management_console/views/workflows/EditWorkflow.js
@@ -1,6 +1,7 @@
 // Copyright 2015, EMC, Inc.
 
 import React, { Component, PropTypes } from 'react';
+import { browserHistory } from 'react-router';
 
 import Select from 'react-select';
 
@@ -82,7 +83,7 @@ export default class EditWorkflow extends Component {
           <ToolbarGroup key={1} lastChild={true}>
             <RaisedButton
                 label="Cancel"
-                onClick={this.props.onDone || this.routeBack}
+                onClick={this.props.onDone || browserHistory.goBack.bind(this)}
                 disabled={this.state.disabled} />
             <RaisedButton
                 label="Save"


### PR DESCRIPTION
The "Cancel" button doesn't take effect on all editors, like in management console, 

1. "create node"
2. "create workflows"
3. "create pollers"
4. "edit pollers" 
5. "create sku"
6. "create file"
7. "create profile"
8. "create template"

Users are kept on the same webpage after clicking the "cancel" button.

## Cause
`this.context.router` is undefined in current react component.
- "react": "^15.3.1",
- "react-router": "^2.7.0"

In current  React Router version , there is no `context.router`. So use `browserHistory` instead.

@panpan0000 @anhou @changev @bbcyyb @pengz1 