### PR TITLE
fix Bug of Adding Null-RAC-4407

### DIFF
--- a/src/workflow_editor/lib/ObjectDiff.js
+++ b/src/workflow_editor/lib/ObjectDiff.js
@@ -71,7 +71,8 @@ export default class ObjectDiff {
       if (handler && handler(current, diff)) { return; }
 
       if (diff.operation === 'remove') {
-        delete current[last];
+       // delete current[last];
+       current.splice(last,1);    
       }
       else {
         current[last] = diff.value;


### PR DESCRIPTION
Background : 
In workflow editor , when we delete a item of an array , we can not really delete it , UI will add null for this item 's value , if we put this "null" value to rackhd , it will validate failed. 
Details : 
In code to process the value of UI , we use "delete array[index]" to delete this item . however , this can not really change the length of array , it just delete the item 's value . so we need change this . 
test : 
manual test 
reviewer : 
@panpan0000 @anhou (please help to review ,thanks)