### PR TITLE
[RAC-6521]fix bug: current.splice is not a function

### DIFF
--- a/src/workflow_editor/lib/ObjectDiff.js
+++ b/src/workflow_editor/lib/ObjectDiff.js
@@ -71,8 +71,11 @@ export default class ObjectDiff {
       if (handler && handler(current, diff)) { return; }
 
       if (diff.operation === 'remove') {
-       // delete current[last];
-       current.splice(last,1);    
+          if (Array.isArray(current)) {
+              current.splice(last, 1);
+          } else {
+              delete current[last];
+          }
       }
       else {
         current[last] = diff.value;


### PR DESCRIPTION
In the source file `src/workflow_editor/lib/ObjectDiff.js`, the variable “current” is multiplexed. It can be "array object" or "json object". So it needs to be a judge here.